### PR TITLE
fix(metrics-server): Improve HPA memory display and icon updates

### DIFF
--- a/modules/web/extensions/metrics-server/src/components/Hpa/HpaTable/HpaTable.tsx
+++ b/modules/web/extensions/metrics-server/src/components/Hpa/HpaTable/HpaTable.tsx
@@ -23,6 +23,7 @@ import store from '../../../stores/hpa';
 import { HpaCreateModal } from '../HpaCreateModal/HpaCreateModal';
 import { HpaStatus } from '../HpaStatus/HpaStatus';
 import { HpaEditModal } from '../HpaEditModal/HpaEditModal';
+import { transformBytes } from '../../../utils';
 
 const { useQueryList } = store;
 
@@ -278,7 +279,12 @@ export const HpaTable = (props: HpaTableProps) => {
         enableHiding: true,
         cell: info => {
           const { memoryCurrentValue = 0, memoryTargetValue = 0 } = info.row.original;
-          return <Field value={memoryTargetValue} label={`当前：${memoryCurrentValue}`} />;
+          return (
+            <Field
+              value={memoryTargetValue}
+              label={`${t('metricsServer.current')}：${transformBytes(memoryCurrentValue)}`}
+            />
+          );
         },
       },
       {

--- a/modules/web/extensions/metrics-server/src/events/index.tsx
+++ b/modules/web/extensions/metrics-server/src/events/index.tsx
@@ -1,4 +1,4 @@
-import { Pen, Stretch, SmcDuotone } from '@kubed/icons';
+import { SmcDuotone } from '@kubed/icons';
 import { pick } from 'lodash';
 import { default as React } from 'react';
 import { HpaModal } from '../components/Hpa';
@@ -12,7 +12,7 @@ export const events = {
     ) => {
       return {
         ...point,
-        icon: <Stretch size={40} />,
+        icon: <SmcDuotone size={40} />,
       };
     },
     'pageNav://pageNav.workspace.workloads.statefulsets-detail.metrics-server': (
@@ -21,7 +21,7 @@ export const events = {
     ) => {
       return {
         ...point,
-        icon: <Stretch size={40} />,
+        icon: <SmcDuotone size={40} />,
       };
     },
     'pageAction://pageAction.cluster.deployments.detail.metrics-server': (
@@ -39,8 +39,6 @@ export const events = {
       modalDispatch: any,
       context: any,
     ) => {
-      console.log('context', context);
-
       modalDispatch.show('open.workspace.hpa', {
         modal: HpaModal,
         detail: context.detail,

--- a/modules/web/extensions/metrics-server/src/locales/en/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/en/base.json
@@ -28,5 +28,6 @@
   "metricsServer.field.project": "Project",
   "metricsServer.editYaml": "Edit YAML",
   "metricsServer.delete": "Delete",
-  "metricsServer.modal.create.title": "Create Pod Horizontal Auto Scaling"
+  "metricsServer.modal.create.title": "Create Pod Horizontal Auto Scaling",
+  "metricsServer.namespace": "Project"
 }

--- a/modules/web/extensions/metrics-server/src/locales/es/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/es/base.json
@@ -28,5 +28,6 @@
   "metricsServer.field.project": "Proyecto",
   "metricsServer.editYaml": "Editar YAML",
   "metricsServer.delete": "Eliminar",
-  "metricsServer.modal.create.title": "Crear escalado horizontal de Pod"
+  "metricsServer.modal.create.title": "Crear escalado horizontal de Pod",
+  "metricsServer.namespace": "Proyecto"
 }

--- a/modules/web/extensions/metrics-server/src/locales/tc/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/tc/base.json
@@ -27,5 +27,6 @@
   "metricsServer.field.project": "項目",
   "metricsServer.editYaml": "編輯 YAML",
   "metricsServer.delete": "刪除",
-  "metricsServer.modal.create.title": "創建 Pod 水平自動擴縮"
+  "metricsServer.modal.create.title": "創建 Pod 水平自動擴縮",
+  "metricsServer.namespace": "項目"
 }

--- a/modules/web/extensions/metrics-server/src/locales/zh/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/zh/base.json
@@ -27,5 +27,6 @@
   "metricsServer.field.project": "项目",
   "metricsServer.editYaml": "编辑 YAML",
   "metricsServer.delete": "删除",
-  "metricsServer.modal.create.title": "创建 Pod 水平自动扩缩"
+  "metricsServer.modal.create.title": "创建 Pod 水平自动扩缩",
+  "metricsServer.namespace": "项目"
 }

--- a/modules/web/extensions/metrics-server/src/stores/hpa.ts
+++ b/modules/web/extensions/metrics-server/src/stores/hpa.ts
@@ -1,6 +1,5 @@
 import { getBaseInfo, getOriginData, PathParams, getApiVersion } from '@ks-console/shared';
 import { getStoreWithQueryHooks } from './useStore';
-import { get } from 'lodash';
 import BaseStore from './base';
 
 // @ts-expect-error
@@ -16,10 +15,8 @@ const mapper = (item: Record<string, any>) => {
   const { spec = {}, status } = item;
   const cpuTargetUtilization = findMetric(spec?.metrics, 'cpu')?.target?.averageUtilization || '';
   const memoryTargetValue = findMetric(spec?.metrics, 'memory')?.target?.averageValue || '';
-  const cpuCurrentUtilization =
-    findCurrent(status?.currentMetrics, 'cpu')?.current?.averageUtilization || 0;
-  const memoryCurrentValue =
-    findCurrent(status?.currentMetrics, 'memory')?.current?.averageValue || 0;
+  const cpuCurrentUtilization = findCurrent(status?.currentMetrics, 'cpu')?.averageValue || 0;
+  const memoryCurrentValue = findCurrent(status?.currentMetrics, 'memory')?.averageValue || 0;
 
   return {
     ...baseInfo,
@@ -35,11 +32,8 @@ const mapper = (item: Record<string, any>) => {
 
 const module = 'horizontalpodautoscalers';
 
-// http://localhost:8000/clusters/host/apis/autoscaling/v2/namespaces/springboot-demo/horizontalpodautoscalers/111?name=111&labelSelector=autoscaling.kubeshpere.io%2Fscale-target-kind%3DDeployment,autoscaling.kubeshpere.io%2Fscale-target-name%3Dspringboot-actuator-demo&sortBy=createTime&limit=10
-
 const getResourceUrl = (params: PathParams = {}) => {
   const apiVersion = getApiVersion(module, globals.clusterConfig?.[params.cluster!]?.k8sVersion);
-  // return `${apiVersion}/${getPath(params)}/${module}`;
   const url = `/clusters/${params.cluster}/kapis/${apiVersion}/namespaces/${params.namespace}/horizontalpodautoscalers`;
   return url;
 };
@@ -48,7 +42,6 @@ const baseStore = BaseStore({
   module,
   mapper,
   getResourceUrlFn: getResourceUrl,
-  // getListUrlFn: getResourceUrl,
 });
 
 export default getStoreWithQueryHooks(baseStore);

--- a/modules/web/extensions/metrics-server/src/utils/index.ts
+++ b/modules/web/extensions/metrics-server/src/utils/index.ts
@@ -143,3 +143,22 @@ export const coreUnitTS = (value: number, unit: string) => {
 
   return unitTxt;
 };
+
+export const transformBytes = (value: number) => {
+  const units = ['Bytes', 'Ki', 'Mi', 'Gi', 'Ti'];
+  const base = 1024;
+  let index = 0;
+
+  // Continue conversion while value >= 1024 and there are larger units available
+  while (value >= base && index < units.length - 1) {
+    value /= base;
+    index++;
+  }
+
+  // For very small values (less than 1), return 0
+  if (value < 1 && index === 0) {
+    return '0';
+  }
+
+  return `${value.toFixed(2)}${units[index]}`;
+};


### PR DESCRIPTION
- Add memory value transformation to display in readable units (Bytes, Ki, Mi, Gi, Ti)
- Replace Stretch icon with SmcDuotone icon in HPA related pages
- Update memory current value display format in HPA table
- Add namespace translation keys across different locales
- Clean up unused imports and console logs
- Fix CPU and memory current metrics path in mapper function

related issue: https://github.com/kubesphere/project/issues/4944
Signed-off-by: leioy <wlbyan@icloud.com>