### PR TITLE
refactor(metrics-server): remove unused imports and fix display issues

### DIFF
--- a/modules/web/extensions/metrics-server/src/components/Hpa/HpaCreateModal/HpaCreateModal.tsx
+++ b/modules/web/extensions/metrics-server/src/components/Hpa/HpaCreateModal/HpaCreateModal.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Form, FormItem, Input, Modal, notify, useForm } from '@kubed/components';
 import { BasePathParams, hpaStore, NumberInput } from '@ks-console/shared';
 import styled from 'styled-components';
-import { get } from 'lodash';
 
 type HpaFormModalProps = {
   detail?: any;
@@ -29,7 +28,7 @@ const HpaFormInner = styled.div`
 
 const { createHpa } = hpaStore;
 export const HpaCreateModal = (props: HpaFormModalProps) => {
-  const { detail, workloadStore, params, onOk, onCancel, open } = props;
+  const { detail, params, onOk, onCancel, open } = props;
 
   const { name, namespace } = params;
   const { uid, kind } = detail;
@@ -65,14 +64,6 @@ export const HpaCreateModal = (props: HpaFormModalProps) => {
     },
   };
 
-  const { useUpdateDeploymentMutation } = workloadStore;
-
-  const mutateUpdateDeploymentMutation = useUpdateDeploymentMutation({
-    onSuccess: () => {
-      notify.success(t('metricsServer.createSuccess'));
-    },
-  });
-
   const [form] = useForm();
   const onFinish = () => {
     form.validateFields().then(() => {
@@ -83,16 +74,7 @@ export const HpaCreateModal = (props: HpaFormModalProps) => {
 
   const onCreate = async (formValues: any) => {
     await createHpa(detail, formValues);
-    mutateUpdateDeploymentMutation.mutate({
-      params: detail,
-      data: {
-        metadata: {
-          annotations: {
-            'kubesphere.io/relatedHPA': get(formValues, 'metadata.name', detail.name),
-          },
-        },
-      },
-    });
+    notify.success(t('metricsServer.createSuccess'));
     onOk();
     form.resetFields();
   };

--- a/modules/web/extensions/metrics-server/src/components/Hpa/HpaTable/HpaTable.tsx
+++ b/modules/web/extensions/metrics-server/src/components/Hpa/HpaTable/HpaTable.tsx
@@ -302,7 +302,11 @@ export const HpaTable = (props: HpaTableProps) => {
           return (
             <Field
               value={memoryTargetValue}
-              label={`${t('metricsServer.current')}：${transformBytes(memoryCurrentValue)}`}
+              label={
+                memoryCurrentValue
+                  ? `${t('metricsServer.current')}：${transformBytes(memoryCurrentValue)}`
+                  : '--'
+              }
             />
           );
         },

--- a/modules/web/extensions/metrics-server/src/events/index.tsx
+++ b/modules/web/extensions/metrics-server/src/events/index.tsx
@@ -20,7 +20,7 @@ export const events = {
       return {
         ...point,
         disabled,
-        show: hasClusterModule(context.detail.cluster, 'metrics-server'),
+        show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
         icon: <SmcDuotone size={40} />,
       };
     },
@@ -36,7 +36,7 @@ export const events = {
       return {
         ...point,
         disabled,
-        show: hasClusterModule(context.detail.cluster, 'metrics-server'),
+        show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
         icon: <SmcDuotone size={40} />,
       };
     },


### PR DESCRIPTION
- Remove unused lodash import and workloadStore dependency
- Simplify HPA creation logic by removing unnecessary mutation
- Fix memory current value display with null check
- Add optional chaining to prevent undefined access errors

related issue: https://github.com/kubesphere/project/issues/6457#issuecomment-3056357561