### PR TITLE
fix(metrics-server): improve memory value handling in HPA table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode/
 .idea/
+AGENTS.md
+CLAUDE.local.md

--- a/modules/web/extensions/metrics-server/src/components/Hpa/HpaTable/HpaTable.tsx
+++ b/modules/web/extensions/metrics-server/src/components/Hpa/HpaTable/HpaTable.tsx
@@ -299,13 +299,12 @@ export const HpaTable = (props: HpaTableProps) => {
         enableHiding: true,
         cell: info => {
           const { memoryCurrentValue = 0, memoryTargetValue = 0 } = info.row.original;
+          const parsedValue = parseFloat(memoryCurrentValue);
           return (
             <Field
               value={memoryTargetValue}
               label={
-                memoryCurrentValue
-                  ? `${t('metricsServer.current')}：${transformBytes(memoryCurrentValue)}`
-                  : '--'
+                parsedValue ? `${t('metricsServer.current')}：${transformBytes(parsedValue)}` : '--'
               }
             />
           );


### PR DESCRIPTION
- Add AGENTS.md and CLAUDE.local.md to .gitignore to exclude agent-related files
- Fix memory current value parsing in HpaTable component by converting string to float before display
- Remove unnecessary null check since parseFloat handles empty values gracefully

issue: https://github.com/kubesphere/project/issues/6857