### PR TITLE
fix: disable HTML entity escaping in HPA status messages

### DIFF
--- a/modules/web/extensions/metrics-server/src/components/HpaStatus/HpaStatus.tsx
+++ b/modules/web/extensions/metrics-server/src/components/HpaStatus/HpaStatus.tsx
@@ -59,7 +59,13 @@ export function HpaStatus({ status, onClick }: HpaStatusProps) {
             <ul>
               <li>{t('STATUS_VALUE', { value: item.status })}</li>
               <li>{item.reason && t('REASON_VALUE', { value: item.reason })}</li>
-              <li>{item.message && t('MESSAGE_VALUE', { value: item.message })}</li>
+              <li>
+                {item.message &&
+                  t('MESSAGE_VALUE', {
+                    value: item.message,
+                    interpolation: { escapeValue: false },
+                  })}
+              </li>
             </ul>
           </TextItem>
         ))}


### PR DESCRIPTION
  Prevent i18next from escaping HTML entities in message values by
  setting escapeValue to false, allowing proper display of characters
  like apostrophes from backend API responses

issue：https://github.com/kubesphere/project/issues/6876