### PR TITLE
fix: improve UI consistency and empty states in HPA pages

### DIFF
--- a/modules/web/extensions/metrics-server/src/components/WorkloadSheet/HpaTable.tsx
+++ b/modules/web/extensions/metrics-server/src/components/WorkloadSheet/HpaTable.tsx
@@ -13,7 +13,7 @@ import {
   EventsSheet,
 } from '@ks-console/shared';
 import { Card, DataTable, Field } from '@kubed/components';
-import { Pen, Trash, Stretch } from '@kubed/icons';
+import { Pen, Trash } from '@kubed/icons';
 import { ColumnDef, Table } from '@tanstack/react-table';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -503,7 +503,7 @@ export const HpaTable = (props: HpaTableProps) => {
       {isEmpty ? (
         <Card padding={32}>
           <Empty
-            icon={<Stretch size={48} />}
+            icon={<HpaIcon size={48} />}
             title={t('hpa.empty.title')}
             desc={t('hpa.empty.description')}
             actions={renderTableAction()}

--- a/modules/web/extensions/metrics-server/src/events/index.tsx
+++ b/modules/web/extensions/metrics-server/src/events/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { HpaModal } from '../components/WorkloadSheet';
 import { hasClusterModule } from '@ks-console/shared';
 import { HpaIcon } from '../components/Icon/HpaIcon';
-import { Tooltip } from '@kubed/components';
 
 export const events = {
   // events
@@ -22,7 +21,7 @@ export const events = {
         ...point,
         disabled,
         show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
-        icon: <HpaIcon size={40} />,
+        icon: <HpaIcon />,
       };
     },
     'pageNav://pageNav.workspace.workloads.statefulsets-detail.metrics-server': (
@@ -38,7 +37,7 @@ export const events = {
         ...point,
         disabled,
         show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
-        icon: <HpaIcon size={40} />,
+        icon: <HpaIcon />,
       };
     },
     'pageNav://pageNav.cluster.deployments.detail.metrics-server': (point: any, context: any) => {
@@ -51,7 +50,7 @@ export const events = {
         ...point,
         disabled,
         show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
-        icon: <HpaIcon size={40} />,
+        icon: <HpaIcon />,
       };
     },
     'pageNav://pageNav.cluster.statefulsets.detail.metrics-server': (point: any, context: any) => {
@@ -64,7 +63,7 @@ export const events = {
         ...point,
         disabled,
         show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
-        icon: <HpaIcon size={40} />,
+        icon: <HpaIcon />,
       };
     },
   },

--- a/modules/web/extensions/metrics-server/src/locales/en/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/en/base.json
@@ -6,6 +6,7 @@
   "hpa.validation.minimumReplicas.required": "Minimum replicas cannot be empty",
   "hpa.validation.maximumReplicas.required": "Maximum replicas cannot be empty",
   "hpa.validation.metrics.required": "Please fill in at least one metric value",
+  "hpa.common.selectClusterOrProject": "Select a cluster or project",
   "hpa.common.statusValue": "Status: {value}",
   "hpa.common.reasonValue": "Reason: {value}",
   "hpa.common.messageValue": "Message: {value}",

--- a/modules/web/extensions/metrics-server/src/locales/es/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/es/base.json
@@ -6,6 +6,7 @@
   "hpa.validation.minimumReplicas.required": "El número mínimo de réplicas no puede estar vacío",
   "hpa.validation.maximumReplicas.required": "El número máximo de réplicas no puede estar vacío",
   "hpa.validation.metrics.required": "Ingrese al menos un valor de indicador",
+  "hpa.common.selectClusterOrProject": "Seleccione un clúster o un proyecto",
   "hpa.common.statusValue": "Estado: {value}",
   "hpa.common.reasonValue": "Razón: {value}",
   "hpa.common.messageValue": "Mensaje: {value}",

--- a/modules/web/extensions/metrics-server/src/locales/tc/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/tc/base.json
@@ -6,6 +6,7 @@
   "hpa.validation.minimumReplicas.required": "最小副本數不能爲空",
   "hpa.validation.maximumReplicas.required": "最大副本數不能爲空",
   "hpa.validation.metrics.required": "請至少填寫一個指標值",
+  "hpa.common.selectClusterOrProject": "請選擇集群或項目",
   "hpa.common.statusValue": "狀態：{value}",
   "hpa.common.reasonValue": "原因：{value}",
   "hpa.common.messageValue": "消息：{value}",

--- a/modules/web/extensions/metrics-server/src/locales/zh/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/zh/base.json
@@ -6,6 +6,7 @@
   "hpa.validation.minimumReplicas.required": "最小副本数不能为空",
   "hpa.validation.maximumReplicas.required": "最大副本数不能为空",
   "hpa.validation.metrics.required": "请至少填写一个指标值",
+  "hpa.common.selectClusterOrProject":"请选择集群或项目",
   "hpa.common.statusValue": "状态：{value}",
   "hpa.common.reasonValue": "原因：{value}",
   "hpa.common.messageValue": "消息：{value}",

--- a/modules/web/extensions/metrics-server/src/pages/cluster/list.tsx
+++ b/modules/web/extensions/metrics-server/src/pages/cluster/list.tsx
@@ -35,6 +35,9 @@ import { WORKLOAD_KIND_TEXT_MAP } from '../../constant';
 const TableWrapper = styled.div`
   .table {
     width: 100%;
+    .table-cell {
+      word-break: break-word;
+    }
   }
 `;
 
@@ -436,6 +439,13 @@ const ClusterHpaList = () => {
           simpleMode: false,
           suggestions: [],
         }),
+        empty: () => {
+          return {
+            image: <HpaIcon size={48} />,
+            title: t('hpa.empty.title'),
+            description: t('hpa.empty.description'),
+          };
+        },
       },
     },
   });

--- a/modules/web/extensions/metrics-server/src/pages/workspace/list.tsx
+++ b/modules/web/extensions/metrics-server/src/pages/workspace/list.tsx
@@ -13,13 +13,13 @@ import {
   useWorkspaceProjectSelect,
   EventsSheet,
   IHpaDetail,
+  PageLayout,
 } from '@ks-console/shared';
 import { Card, DataTable, Field } from '@kubed/components';
-import { Pen, Trash, Stretch } from '@kubed/icons';
+import { Pen, Trash, Role } from '@kubed/icons';
 import { ColumnDef, Table } from '@tanstack/react-table';
 import React from 'react';
 import styled from 'styled-components';
-import { Empty } from '../../components/Empty/Empty';
 import { HpaCreateModal } from '../../components/Modal/HpaCreateModal/HpaCreateModal';
 import { HpaYamlModal } from '../../components/Modal/HpaYamlModal';
 import { HpaStatus } from '../../components/HpaStatus/HpaStatus';
@@ -35,9 +35,12 @@ import { HpaScalerSettingModal } from '../../components/Modal/HpaScalerSettingMo
 import { HpaIcon } from '../../components/Icon/HpaIcon';
 import { WORKLOAD_KIND_TEXT_MAP } from '../../constant';
 
-const Container = styled.div`
-  table .table-cell {
-    word-break: break-word;
+const TableWrapper = styled.div`
+  .table {
+    width: 100%;
+    .table-cell {
+      word-break: break-word;
+    }
   }
 `;
 
@@ -468,6 +471,19 @@ export const WorkSpaceHpaList = () => {
             ],
           };
         },
+        empty: () => {
+          if (!namespaceParams.cluster || !namespaceParams.namespace) {
+            return {
+              image: <Role size={48} />,
+              description: t('hpa.common.selectClusterOrProject'),
+            };
+          }
+          return {
+            image: <HpaIcon size={48} />,
+            title: t('hpa.empty.title'),
+            description: t('hpa.empty.description'),
+          };
+        },
       },
     },
   });
@@ -476,28 +492,13 @@ export const WorkSpaceHpaList = () => {
     tableRef.current = table;
   }, []);
 
-  // const isEmpty =
-  //   isFetched && (!query.page || query.page == 1) && !query.name && !data?.data?.length;
-  const isEmpty = false;
-
   return (
-    <>
-      {isEmpty ? (
-        <Card padding={32}>
-          <Empty
-            icon={<Stretch size={48} />}
-            title={t('hpa.empty.title')}
-            desc={t('hpa.empty.description')}
-            actions={renderTableAction()}
-          />
-        </Card>
-      ) : (
-        <Container>
-          <Card padding={0}>
-            <DataTable.DataTable table={table} />
-          </Card>
-        </Container>
-      )}
-    </>
+    <PageLayout title={t('hpa.title')}>
+      <Card padding={0}>
+        <TableWrapper>
+          <DataTable.DataTable table={table} />
+        </TableWrapper>
+      </Card>
+    </PageLayout>
   );
 };


### PR DESCRIPTION
  - Replace generic Stretch icon with custom HpaIcon across all empty states
  - Standardize icon sizes by removing explicit size props from HpaIcon usage
  - Add i18n support for "select cluster or project" prompt in all languages
  - Enhance workspace HPA list with PageLayout wrapper for better page structure
  - Add word-break styling to table cells to prevent overflow issues
  - Improve empty state logic in workspace list to show contextual messages
  - Remove unused imports (Tooltip, Stretch) to reduce bundle size