### PR TITLE
fix: correct event handler placement for statefulsets detail page

### DIFF
--- a/modules/web/extensions/metrics-server/src/events/index.tsx
+++ b/modules/web/extensions/metrics-server/src/events/index.tsx
@@ -101,16 +101,16 @@ export const events = {
         module: 'deployments',
       });
     },
-  },
-  'pageNav://pageNav.cluster.statefulsets.detail.metrics-server': (
-    modalDispatch: any,
-    context: any,
-  ) => {
-    modalDispatch.show('open.cluster.hpa', {
-      modal: HpaModal,
-      detail: context.detail,
-      params: pick(context.detail, ['name', 'cluster', 'namespace', 'workspace']),
-      module: 'statefulsets',
-    });
+    'pageNav://pageNav.cluster.statefulsets.detail.metrics-server': (
+      modalDispatch: any,
+      context: any,
+    ) => {
+      modalDispatch.show('open.cluster.hpa', {
+        modal: HpaModal,
+        detail: context.detail,
+        params: pick(context.detail, ['name', 'cluster', 'namespace', 'workspace']),
+        module: 'statefulsets',
+      });
+    },
   },
 };


### PR DESCRIPTION
  Move the statefulsets detail page event handler back inside the events
  object to fix incorrect code structure

issue: https://github.com/kubesphere/project/issues/7053