### PR TITLE
fix: add VPA conflict detection and disabled state tooltip

### DIFF
--- a/modules/web/extensions/metrics-server/src/events/index.tsx
+++ b/modules/web/extensions/metrics-server/src/events/index.tsx
@@ -15,11 +15,20 @@ export const events = {
         context,
         'detail._originData.metadata.labels["keda.autoscaling.kubesphere.io/managed"]',
       );
+      const vpaContext = get(
+        context,
+        'detail._originData.metadata.labels["vpa.autoscaling.kubesphere.io/managed"]',
+      );
 
-      const disabled = kedaContext === 'true' || kedaContext === true;
+      const disabled =
+        kedaContext === 'true' ||
+        kedaContext === true ||
+        vpaContext === 'true' ||
+        vpaContext === true;
       return {
         ...point,
         disabled,
+        disabledMessage: t('hpa.disabled.tooltip'),
         show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
         icon: <HpaIcon />,
       };
@@ -32,10 +41,20 @@ export const events = {
         context,
         'detail._originData.metadata.labels["keda.autoscaling.kubesphere.io/managed"]',
       );
-      const disabled = kedaContext === 'true' || kedaContext === true;
+      const vpaContext = get(
+        context,
+        'detail._originData.metadata.labels["vpa.autoscaling.kubesphere.io/managed"]',
+      );
+
+      const disabled =
+        kedaContext === 'true' ||
+        kedaContext === true ||
+        vpaContext === 'true' ||
+        vpaContext === true;
       return {
         ...point,
         disabled,
+        disabledMessage: t('hpa.disabled.tooltip'),
         show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
         icon: <HpaIcon />,
       };
@@ -45,10 +64,20 @@ export const events = {
         context,
         'detail._originData.metadata.labels["keda.autoscaling.kubesphere.io/managed"]',
       );
-      const disabled = kedaContext === 'true' || kedaContext === true;
+      const vpaContext = get(
+        context,
+        'detail._originData.metadata.labels["vpa.autoscaling.kubesphere.io/managed"]',
+      );
+
+      const disabled =
+        kedaContext === 'true' ||
+        kedaContext === true ||
+        vpaContext === 'true' ||
+        vpaContext === true;
       return {
         ...point,
         disabled,
+        disabledMessage: t('hpa.disabled.tooltip'),
         show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
         icon: <HpaIcon />,
       };
@@ -58,10 +87,20 @@ export const events = {
         context,
         'detail._originData.metadata.labels["keda.autoscaling.kubesphere.io/managed"]',
       );
-      const disabled = kedaContext === 'true' || kedaContext === true;
+      const vpaContext = get(
+        context,
+        'detail._originData.metadata.labels["vpa.autoscaling.kubesphere.io/managed"]',
+      );
+
+      const disabled =
+        kedaContext === 'true' ||
+        kedaContext === true ||
+        vpaContext === 'true' ||
+        vpaContext === true;
       return {
         ...point,
         disabled,
+        disabledMessage: t('hpa.disabled.tooltip'),
         show: hasClusterModule(context?.detail.cluster, 'metrics-server'),
         icon: <HpaIcon />,
       };

--- a/modules/web/extensions/metrics-server/src/locales/en/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/en/base.json
@@ -1,4 +1,5 @@
 {
+  "hpa.disabled.tooltip": "Each workload only supports binding to the same type of elastic scaling policy.",
   "hpa.menu.parent.title": "Elastic Scaling",
   "hpa.validation.name.required": "Please enter a name",
   "hpa.validation.namespace.required": "Please select a project",

--- a/modules/web/extensions/metrics-server/src/locales/es/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/es/base.json
@@ -1,4 +1,5 @@
 {
+  "hpa.disabled.tooltip": "Cada carga de trabajo solo admite vincular una misma estrategia de escalado elástico.",
   "hpa.menu.parent.title": "Escalado elástico",
   "hpa.validation.name.required": "Ingrese el nombre",
   "hpa.validation.namespace.required": "Seleccione el proyecto",

--- a/modules/web/extensions/metrics-server/src/locales/tc/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/tc/base.json
@@ -1,4 +1,5 @@
 {
+  "hpa.disabled.tooltip": "每個工作負載只支援綁定同一種彈性伸縮策略。",
   "hpa.menu.parent.title": "彈性伸縮",
   "hpa.validation.name.required": "請輸入名稱",
   "hpa.validation.namespace.required": "請選擇項目",

--- a/modules/web/extensions/metrics-server/src/locales/zh/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/zh/base.json
@@ -1,4 +1,5 @@
 {
+  "hpa.disabled.tooltip": "每个工作负载仅支持绑定同一种弹性伸缩策略。",
   "hpa.menu.parent.title": "弹性伸缩",
   "hpa.validation.name.required": "请输入名称",
   "hpa.validation.namespace.required": "请选择项目",


### PR DESCRIPTION
  - Check for VPA labels in addition to KEDA labels to prevent policy conflicts
  - Add disabled message tooltip explaining workload scaling policy restrictions
  - Apply VPA conflict detection across all workload event handlers (deployments and statefulsets)
  - Add localized tooltip messages in English, Spanish, Traditional Chinese, and Simplified Chinese

issue: https://github.com/kubesphere/project/issues/7056