### PR TITLE
fix: standardize authorization key across HPA components

### DIFF
--- a/modules/web/extensions/metrics-server/src/components/WorkloadDetailSheet/detail.tsx
+++ b/modules/web/extensions/metrics-server/src/components/WorkloadDetailSheet/detail.tsx
@@ -21,8 +21,7 @@ import { HpaEditModal } from '../Modal/HpaEditModal/HpaEditModal';
 import { useDelete } from '../../hooks/useDelete';
 import { HpaScalerSettingModal } from '../Modal/HpaScalerSettingModal/HpaScalerSettingModal';
 import { HpaIcon } from '../Icon/HpaIcon';
-
-const authKey = 'metrics-server';
+import { AUTH_KEY } from '../../constant';
 
 interface WorkloadHpaDetailProps {
   params?: BasePathParams;
@@ -113,6 +112,7 @@ export const WorkloadHpaDetail = (props: WorkloadHpaDetailProps) => {
     const actions: any[] = [
       {
         key: 'edit',
+        action: 'edit',
         icon: <Pen />,
         text: t('hpa.common.editBaseInfo'),
         onClick: (_: any) => {
@@ -129,6 +129,7 @@ export const WorkloadHpaDetail = (props: WorkloadHpaDetailProps) => {
       },
       {
         key: 'editYaml',
+        action: 'edit',
         icon: <Pen />,
         text: t('hpa.common.editYaml'),
         onClick: (_: any) => {
@@ -145,6 +146,7 @@ export const WorkloadHpaDetail = (props: WorkloadHpaDetailProps) => {
       },
       {
         key: 'editScale',
+        action: 'edit',
         icon: <Pen />,
         text: t('hpa.common.editScalerSettings'),
         onClick: (_: any) => {
@@ -161,6 +163,7 @@ export const WorkloadHpaDetail = (props: WorkloadHpaDetailProps) => {
       },
       {
         key: 'delete',
+        action: 'delete',
         icon: <Trash />,
         text: t('hpa.common.delete'),
         onClick: (_: any) => {
@@ -209,9 +212,10 @@ export const WorkloadHpaDetail = (props: WorkloadHpaDetailProps) => {
             },
           },
         ]}
+        params={params}
         activeTab={nav}
         detail={detail}
-        authKey={authKey}
+        authKey={AUTH_KEY}
       />
       {nav === 'resource-status' && <ResourceStatus />}
       {nav === 'events' && <Events detail={detail} module="hpa" />}

--- a/modules/web/extensions/metrics-server/src/components/WorkloadSheet/HpaTable.tsx
+++ b/modules/web/extensions/metrics-server/src/components/WorkloadSheet/HpaTable.tsx
@@ -31,6 +31,7 @@ import { get } from 'lodash';
 import { HpaYamlModal } from '../Modal/HpaYamlModal';
 import { HpaScalerSettingModal } from '../Modal/HpaScalerSettingModal/HpaScalerSettingModal';
 import { HpaIcon } from '../Icon/HpaIcon';
+import { AUTH_KEY } from '../../constant';
 
 const Container = styled.div`
   table .table-cell {
@@ -134,7 +135,7 @@ export const HpaTable = (props: HpaTableProps) => {
   const { deleteHpa } = useDelete();
 
   const renderBatchActions = useBatchActions({
-    authKey: module,
+    authKey: AUTH_KEY,
     params: {
       cluster,
       namespace,
@@ -163,7 +164,7 @@ export const HpaTable = (props: HpaTableProps) => {
   });
 
   const renderItemActions = useItemActions({
-    authKey: module,
+    authKey: AUTH_KEY,
     params: {
       cluster,
       namespace,
@@ -240,7 +241,7 @@ export const HpaTable = (props: HpaTableProps) => {
   });
 
   const renderTableAction = useTableActions({
-    authKey: module,
+    authKey: AUTH_KEY,
     params: {
       cluster,
       namespace,

--- a/modules/web/extensions/metrics-server/src/constant.ts
+++ b/modules/web/extensions/metrics-server/src/constant.ts
@@ -25,4 +25,13 @@ const ICON_TYPES = {
   Unknown: { name: 'question', color: '#E0992C' },
 };
 
-export { WORKLOAD_KIND_MAP, STATUS_TITLE, STATUS_DESCRIPTION, ICON_TYPES, WORKLOAD_KIND_TEXT_MAP };
+const AUTH_KEY = 'autoscaling';
+
+export {
+  WORKLOAD_KIND_MAP,
+  STATUS_TITLE,
+  STATUS_DESCRIPTION,
+  ICON_TYPES,
+  WORKLOAD_KIND_TEXT_MAP,
+  AUTH_KEY,
+};

--- a/modules/web/extensions/metrics-server/src/menus/index.ts
+++ b/modules/web/extensions/metrics-server/src/menus/index.ts
@@ -48,6 +48,7 @@ export const menus = [
     icon: 'stretch',
     order: 2,
     skipIfExist: true,
+    skipWorkspaceAuth: true,
   },
   {
     parent: 'workspace.elastic_scaling',

--- a/modules/web/extensions/metrics-server/src/pages/cluster/detail.tsx
+++ b/modules/web/extensions/metrics-server/src/pages/cluster/detail.tsx
@@ -21,6 +21,7 @@ import { HpaYamlModal } from '../../components/Modal/HpaYamlModal';
 import { useDelete } from '../../hooks/useDelete';
 import { HpaScalerSettingModal } from '../../components/Modal/HpaScalerSettingModal/HpaScalerSettingModal';
 import { HpaIcon } from '../../components/Icon/HpaIcon';
+import { AUTH_KEY } from '../../constant';
 const ClusterHpaDetail = () => {
   const navigate = useNavigate();
   const { cluster, namespace, name } = useParams();
@@ -169,7 +170,7 @@ const ClusterHpaDetail = () => {
   return (
     <>
       <DetailPage
-        authKey="metrics-server"
+        authKey={AUTH_KEY}
         tabs={tabs}
         cardProps={{
           name: getDisplayName(detail),

--- a/modules/web/extensions/metrics-server/src/pages/cluster/list.tsx
+++ b/modules/web/extensions/metrics-server/src/pages/cluster/list.tsx
@@ -31,7 +31,7 @@ import { HpaYamlModal } from '../../components/Modal/HpaYamlModal';
 import { useDelete } from '../../hooks/useDelete';
 import { HpaScalerSettingModal } from '../../components/Modal/HpaScalerSettingModal/HpaScalerSettingModal';
 import { HpaIcon } from '../../components/Icon/HpaIcon';
-import { WORKLOAD_KIND_TEXT_MAP } from '../../constant';
+import { WORKLOAD_KIND_TEXT_MAP, AUTH_KEY } from '../../constant';
 const TableWrapper = styled.div`
   .table {
     width: 100%;
@@ -63,7 +63,6 @@ const useSteps = (steps: number[]) => {
 const ClusterHpaList = () => {
   const useHpaStore = createHpaStore();
   const { cluster } = useParams();
-  const authKey = 'deployments';
   const tableRef = React.useRef<Table<RecordType>>();
   const { state, setState } = useUrlSearchParamsStatus([]);
   const { render: renderProjectSelect, params } = useProjectSelect();
@@ -110,7 +109,7 @@ const ClusterHpaList = () => {
   const { deleteHpa } = useDelete();
 
   const renderItemActions = useItemActions({
-    authKey: authKey,
+    authKey: AUTH_KEY,
     params: {
       cluster,
     },
@@ -338,7 +337,7 @@ const ClusterHpaList = () => {
   ];
 
   const renderBatchActions = useBatchActions({
-    authKey,
+    authKey: AUTH_KEY,
     params: {
       cluster,
     },
@@ -366,7 +365,7 @@ const ClusterHpaList = () => {
   });
 
   const renderTableActions = useTableActions({
-    authKey: authKey,
+    authKey: AUTH_KEY,
     params: {
       cluster,
     },

--- a/modules/web/extensions/metrics-server/src/pages/workspace/detail.tsx
+++ b/modules/web/extensions/metrics-server/src/pages/workspace/detail.tsx
@@ -21,6 +21,7 @@ import { useDelete } from '../../hooks/useDelete';
 import { useNavigate } from 'react-router-dom';
 import { HpaScalerSettingModal } from '../../components/Modal/HpaScalerSettingModal/HpaScalerSettingModal';
 import { HpaIcon } from '../../components/Icon/HpaIcon';
+import { AUTH_KEY } from '../../constant';
 const WorkspaceHpaDetail = () => {
   const { cluster, namespace, workspace, name } = useParams();
   const [detail, setDetail] = useStore<any>('hpaDetail');
@@ -170,7 +171,7 @@ const WorkspaceHpaDetail = () => {
     <>
       <DetailPage
         tabs={tabs}
-        authKey="metrics-server"
+        authKey={AUTH_KEY}
         cardProps={{
           name: getDisplayName(detail),
           desc: detail?.description,

--- a/modules/web/extensions/metrics-server/src/pages/workspace/list.tsx
+++ b/modules/web/extensions/metrics-server/src/pages/workspace/list.tsx
@@ -33,7 +33,7 @@ import { useParams } from 'react-router-dom';
 import { get } from 'lodash';
 import { HpaScalerSettingModal } from '../../components/Modal/HpaScalerSettingModal/HpaScalerSettingModal';
 import { HpaIcon } from '../../components/Icon/HpaIcon';
-import { WORKLOAD_KIND_TEXT_MAP } from '../../constant';
+import { WORKLOAD_KIND_TEXT_MAP, AUTH_KEY } from '../../constant';
 
 const TableWrapper = styled.div`
   .table {
@@ -117,7 +117,7 @@ export const WorkSpaceHpaList = () => {
   const { deleteHpa } = useDelete();
 
   const renderBatchActions = useBatchActions({
-    authKey: '',
+    authKey: AUTH_KEY,
     params: {
       cluster: namespaceParams?.cluster,
       namespace: namespaceParams?.namespace,
@@ -146,7 +146,7 @@ export const WorkSpaceHpaList = () => {
   });
 
   const renderItemActions = useItemActions({
-    authKey: '',
+    authKey: AUTH_KEY,
     params: {
       cluster: namespaceParams?.cluster,
       namespace: namespaceParams?.namespace,
@@ -223,7 +223,7 @@ export const WorkSpaceHpaList = () => {
   });
 
   const renderTableAction = useTableActions({
-    authKey: '',
+    authKey: AUTH_KEY,
     params: {
       cluster: namespaceParams?.cluster,
       namespace: namespaceParams?.namespace,


### PR DESCRIPTION
  - Replace hardcoded 'metrics-server' and module-based authKeys with centralized AUTH_KEY constant ('autoscaling')
  - Add AUTH_KEY constant to constants file for consistent authorization checks
  - Add action properties to detail page action items for proper permission validation
  - Add skipWorkspaceAuth flag to cluster elastic scaling menu
  - Update all table actions, item actions, and batch actions to use unified AUTH_KEY

issue: https://github.com/kubesphere/project/issues/7058
https://github.com/kubesphere/project/issues/7062