### PR TITLE
fix: adjust layout spacing in HPA create modal

### DIFF
--- a/modules/web/extensions/metrics-server/src/components/Form/AdvancedForm/styles.ts
+++ b/modules/web/extensions/metrics-server/src/components/Form/AdvancedForm/styles.ts
@@ -6,6 +6,7 @@ export const FormContent = styled.div`
   border-radius: 4px;
   & .form-item-wrapper {
     margin-bottom: 0;
+    flex: 1;
   }
 `;
 

--- a/modules/web/extensions/metrics-server/src/components/Modal/HpaCreateModal/styles.ts
+++ b/modules/web/extensions/metrics-server/src/components/Modal/HpaCreateModal/styles.ts
@@ -5,6 +5,7 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding-right: 24px;
 `;
 
 export { Header };


### PR DESCRIPTION
  - Add flex: 1 to form-item-wrapper in AdvancedForm for better field width distribution
  - Add right padding to modal header for proper alignment with close button

issue：https://github.com/kubesphere/project/issues/7046