### PR TITLE
fix: add alias name input length limit and correct minimum replicas h…

### DIFF
--- a/modules/web/extensions/metrics-server/src/components/Modal/HpaEditModal/HpaEditModal.tsx
+++ b/modules/web/extensions/metrics-server/src/components/Modal/HpaEditModal/HpaEditModal.tsx
@@ -87,7 +87,7 @@ export const HpaEditModal = (props: HpaFormModalProps) => {
               help={t('hpa.common.aliasName.help')}
               name={['metadata', 'annotations', 'kubesphere.io/alias-name']}
             >
-              <Input />
+              <Input maxLength={63} />
             </FormItem>
             <FormItem
               label={t('hpa.common.description')}

--- a/modules/web/extensions/metrics-server/src/locales/en/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/en/base.json
@@ -77,7 +77,7 @@
   "hpa.range": "Replica Range",
   "hpa.desiredReplicas": "Desired Replicas",
   "hpa.minimumReplicas": "Minimum Replicas",
-  "hpa.minimumReplicas.help": "Set the minimum allowed number of pod replicas, default value is 0.",
+  "hpa.minimumReplicas.help": "Set the minimum allowed number of pod replicas, default value is 1.",
   "hpa.maximumReplicas": "Maximum Replicas",
   "hpa.maximumReplicas.help": "Set the maximum allowed number of pod replicas, default value is 1.",
   "hpa.modal.create.title": "Create Horizontal Pod Autoscaler",

--- a/modules/web/extensions/metrics-server/src/locales/es/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/es/base.json
@@ -77,7 +77,7 @@
   "hpa.range": "Rango de réplicas",
   "hpa.desiredReplicas": "Número de réplicas deseado",
   "hpa.minimumReplicas": "Mínimo de réplicas",
-  "hpa.minimumReplicas.help": "Establezca el número mínimo de réplicas de pods permitidas, con un valor predeterminado de 0.",
+  "hpa.minimumReplicas.help": "Establezca el número mínimo de réplicas de pods permitidas, con un valor predeterminado de 1.",
   "hpa.maximumReplicas": "Máximo de réplicas",
   "hpa.maximumReplicas.help": "Establezca el número máximo de réplicas de pods permitidas, con un valor predeterminado de 1.",
   "hpa.modal.create.title": "Crear escalado horizontal de Pod",

--- a/modules/web/extensions/metrics-server/src/locales/tc/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/tc/base.json
@@ -77,7 +77,7 @@
   "hpa.range": "副本數量範圍",
   "hpa.desiredReplicas": "期望副本數",
   "hpa.minimumReplicas": "最小副本數",
-  "hpa.minimumReplicas.help": "設置允許的最小容器組副本數量，默認值爲 0。",
+  "hpa.minimumReplicas.help": "設置允許的最小容器組副本數量，默認值爲 1。",
   "hpa.maximumReplicas": "最大副本數",
   "hpa.maximumReplicas.help": "設置允許的最大容器組副本數量，默認值爲 1。",
   "hpa.modal.create.title": "創建容器水平伸縮",

--- a/modules/web/extensions/metrics-server/src/locales/zh/base.json
+++ b/modules/web/extensions/metrics-server/src/locales/zh/base.json
@@ -77,7 +77,7 @@
   "hpa.range": "副本数量范围",
   "hpa.desiredReplicas": "期望副本数",
   "hpa.minimumReplicas": "最小副本数",
-  "hpa.minimumReplicas.help": "设置允许的最小容器组副本数量，默认值为 0。",
+  "hpa.minimumReplicas.help": "设置允许的最小容器组副本数量，默认值为 1。",
   "hpa.maximumReplicas": "最大副本数",
   "hpa.maximumReplicas.help": "设置允许的最大容器组副本数量，默认值为 1。",
   "hpa.modal.create.title": "创建容器水平伸缩",


### PR DESCRIPTION
…elp text

  - Add maxLength={63} constraint to alias name input field in HPA edit modal to comply with Kubernetes annotation length limits
  - Update minimum replicas help text from "default value is 0" to "default value is 1" across all locales (en, es, zh, tc) to reflect actual HPA behavior

issue: https://github.com/kubesphere/project/issues/7040